### PR TITLE
[TASK-P3-006] Add runtime multi-company record rules

### DIFF
--- a/dynamic_approval_workflow/dynamic_approval_core/security/workflow_security.xml
+++ b/dynamic_approval_workflow/dynamic_approval_core/security/workflow_security.xml
@@ -84,6 +84,33 @@
         </field>
     </record>
 
+    <record id="rule_workflow_node_runtime_company" model="ir.rule">
+        <field name="name">Workflow Node Runtime: multi-company</field>
+        <field name="model_id" ref="model_workflow_node_runtime"/>
+        <field name="domain_force">
+            ['|', ('company_id', '=', False),
+                  ('company_id', 'in', company_ids)]
+        </field>
+    </record>
+
+    <record id="rule_workflow_token_company" model="ir.rule">
+        <field name="name">Workflow Token: multi-company</field>
+        <field name="model_id" ref="model_workflow_token"/>
+        <field name="domain_force">
+            ['|', ('company_id', '=', False),
+                  ('company_id', 'in', company_ids)]
+        </field>
+    </record>
+
+    <record id="rule_workflow_decision_event_company" model="ir.rule">
+        <field name="name">Workflow Decision Event: multi-company</field>
+        <field name="model_id" ref="model_workflow_decision_event"/>
+        <field name="domain_force">
+            ['|', ('company_id', '=', False),
+                  ('company_id', 'in', company_ids)]
+        </field>
+    </record>
+
     <record id="rule_workflow_task_company" model="ir.rule">
         <field name="name">Workflow Task: multi-company</field>
         <field name="model_id" ref="model_workflow_task"/>


### PR DESCRIPTION
Task ID: `TASK-P3-006`

## Summary
- add missing multi-company record rules for runtime models: `workflow.node.runtime`, `workflow.token`, and `workflow.decision.event`
- keep existing instance rule and ACL rows intact
- align runtime model access control with Phase-3 acceptance criteria

## Files Changed
- `dynamic_approval_workflow/dynamic_approval_core/security/workflow_security.xml`

## Verification
- `python3 scripts/check_odoo19_compat.py`
- `./odoo.sh -d test_task_p3_006 -i dynamic_approval_core --stop-after-init --without-demo`

Closes #26
