### PR TITLE
feat: implement condition and follower rule contracts (TASK-P1-005)

### DIFF
--- a/dynamic_approval_workflow/dynamic_approval_core/models/workflow_condition_rule.py
+++ b/dynamic_approval_workflow/dynamic_approval_core/models/workflow_condition_rule.py
@@ -1,4 +1,9 @@
-from odoo import fields, models
+import json
+from json import JSONDecodeError
+
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+from odoo.tools.safe_eval import safe_eval
 
 
 class WorkflowConditionRule(models.Model):
@@ -11,7 +16,7 @@ class WorkflowConditionRule(models.Model):
     _description = "Workflow Condition Rule"
     _order = "sequence"
 
-    name = fields.Char(required=True)
+    name = fields.Char(size=128, required=True)
     definition_version_id = fields.Many2one(
         "workflow.definition.version",
         required=True,
@@ -20,11 +25,15 @@ class WorkflowConditionRule(models.Model):
     )
     source_node_id = fields.Char(
         string="Source BPMN Node",
+        size=64,
         required=True,
+        index=True,
     )
     target_node_id = fields.Char(
         string="Target BPMN Node",
+        size=64,
         required=True,
+        index=True,
     )
     sequence = fields.Integer(default=10)
     condition_type = fields.Selection(
@@ -42,10 +51,96 @@ class WorkflowConditionRule(models.Model):
         help="Admin-only sandboxed Python expression.",
     )
     is_default = fields.Boolean(
+        default=False,
         help="Default path when no other condition matches.",
     )
     company_id = fields.Many2one(
         related="definition_version_id.company_id",
         store=True,
         index=True,
+        readonly=True,
     )
+
+    @api.constrains("condition_type", "domain_filter", "python_code")
+    def _check_condition_value(self):
+        """Validate required values and syntax for the selected condition type."""
+        for record in self:
+            if record.condition_type == "domain":
+                if not record.domain_filter:
+                    raise ValidationError(_("Domain filter is required for domain conditions."))
+                record._parse_domain_filter()
+                continue
+
+            if record.condition_type == "python":
+                if not record.python_code:
+                    raise ValidationError(_("Python code is required for python conditions."))
+                record._validate_python_expression()
+
+    @api.constrains("definition_version_id", "source_node_id", "is_default")
+    def _check_single_default_per_source_node(self):
+        """Allow at most one default path per source node in a version."""
+        for record in self.filtered("is_default"):
+            default_count = self.search_count(
+                [
+                    ("definition_version_id", "=", record.definition_version_id.id),
+                    ("source_node_id", "=", record.source_node_id),
+                    ("is_default", "=", True),
+                ]
+            )
+            if default_count > 1:
+                raise ValidationError(_("Only one default condition is allowed per source node."))
+
+    def _parse_domain_filter(self):
+        """Parse and validate domain_filter JSON."""
+        self.ensure_one()
+        try:
+            parsed_domain = json.loads(self.domain_filter or "")
+        except JSONDecodeError as err:
+            raise ValidationError(_("Domain filter must be valid JSON.")) from err
+        if not isinstance(parsed_domain, list):
+            raise ValidationError(_("Domain filter JSON must be a list."))
+        return parsed_domain
+
+    def _validate_python_expression(self):
+        """Ensure python_code is syntactically valid for safe eval."""
+        self.ensure_one()
+        try:
+            compile(self.python_code or "", "<workflow_condition_rule>", "eval")
+        except SyntaxError as err:
+            raise ValidationError(_("Python condition must be a valid expression.")) from err
+
+    def evaluate(self, record, context):
+        """Evaluate the condition against a single business record."""
+        self.ensure_one()
+        if len(record) != 1:
+            raise ValidationError(_("Condition evaluation expects exactly one target record."))
+
+        if self.condition_type == "domain":
+            return self._evaluate_domain(record)
+        if self.condition_type == "python":
+            return self._evaluate_python(record, context or {})
+        return False
+
+    def _evaluate_domain(self, record):
+        """Evaluate domain_filter against a single record."""
+        self.ensure_one()
+        parsed_domain = self._parse_domain_filter()
+        record_domain = list(parsed_domain) + [("id", "=", record.id)]
+        return bool(record.search_count(record_domain))
+
+    def _evaluate_python(self, record, context):
+        """Evaluate python_code with a safe context."""
+        self.ensure_one()
+        try:
+            result = safe_eval(
+                self.python_code or "False",
+                {
+                    "record": record,
+                    "context": dict(context or {}),
+                    "env": record.env,
+                },
+                mode="eval",
+            )
+        except Exception as err:
+            raise ValidationError(_("Python condition evaluation failed: %s") % err) from err
+        return bool(result)

--- a/dynamic_approval_workflow/dynamic_approval_core/models/workflow_follower_rule.py
+++ b/dynamic_approval_workflow/dynamic_approval_core/models/workflow_follower_rule.py
@@ -1,4 +1,5 @@
-from odoo import fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 
 
 class WorkflowFollowerRule(models.Model):
@@ -11,7 +12,7 @@ class WorkflowFollowerRule(models.Model):
     _description = "Workflow Follower Rule"
     _order = "sequence"
 
-    name = fields.Char(required=True)
+    name = fields.Char(size=128, required=True)
     definition_version_id = fields.Many2one(
         "workflow.definition.version",
         required=True,
@@ -28,10 +29,64 @@ class WorkflowFollowerRule(models.Model):
         ],
         required=True,
     )
-    group_id = fields.Many2one("res.groups")
-    field_path = fields.Char()
+    group_id = fields.Many2one(
+        "res.groups",
+        ondelete="restrict",
+    )
+    field_path = fields.Char(size=255)
+    completion_policy = fields.Selection(
+        [
+            ("retained", "Retained"),
+            ("downgraded", "Downgraded"),
+            ("removed", "Removed"),
+        ],
+        default="retained",
+    )
     company_id = fields.Many2one(
         related="definition_version_id.company_id",
         store=True,
         index=True,
+        readonly=True,
     )
+
+    @api.constrains("follower_type", "group_id", "field_path")
+    def _check_follower_type_values(self):
+        """Validate required field based on follower_type."""
+        for record in self:
+            if record.follower_type == "group" and not record.group_id:
+                raise ValidationError(_("Group is required when follower type is 'group'."))
+            if record.follower_type == "field" and not record.field_path:
+                raise ValidationError(_("Field path is required when follower type is 'field'."))
+
+    def _resolve_followers(self, requester=None, approvers=None, record=None):
+        """Resolve followers for this rule as a res.users recordset."""
+        self.ensure_one()
+        empty_users = self.env["res.users"]
+        if self.follower_type == "requester":
+            return requester if requester else empty_users
+        if self.follower_type == "approver":
+            return approvers if approvers else empty_users
+        if self.follower_type == "group":
+            return self.group_id.user_ids | self.group_id.all_user_ids
+        if self.follower_type == "field":
+            if not record:
+                return empty_users
+            return self._resolve_users_from_field_path(record)
+        return empty_users
+
+    def _resolve_users_from_field_path(self, record):
+        """Resolve res.users from a dot-separated field path on the target record."""
+        self.ensure_one()
+        current = record
+        for field_name in (self.field_path or "").split("."):
+            if not field_name:
+                continue
+            if field_name not in current._fields:
+                raise ValidationError(_("Invalid field path segment '%s'.") % field_name)
+            current = current.mapped(field_name)
+            if not current:
+                return self.env["res.users"]
+
+        if current._name == "res.users":
+            return current
+        return self.env["res.users"]

--- a/dynamic_approval_workflow/dynamic_approval_core/tests/__init__.py
+++ b/dynamic_approval_workflow/dynamic_approval_core/tests/__init__.py
@@ -6,3 +6,4 @@ from . import test_workflow_runtime
 from . import test_workflow_task
 from . import test_workflow_idempotency
 from . import test_workflow_security
+from . import test_workflow_condition_follower_rule

--- a/dynamic_approval_workflow/dynamic_approval_core/tests/test_workflow_condition_follower_rule.py
+++ b/dynamic_approval_workflow/dynamic_approval_core/tests/test_workflow_condition_follower_rule.py
@@ -1,0 +1,270 @@
+import json
+
+from odoo.exceptions import ValidationError
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase
+
+
+@tagged("post_install", "-at_install")
+class TestWorkflowConditionFollowerRule(TransactionCase):
+    """Tests for workflow.condition.rule and workflow.follower.rule."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.definition = cls.env["workflow.definition"].create(
+            {
+                "name": "Condition Workflow",
+                "definition_key": "condition_workflow",
+            }
+        )
+        cls.version = cls.env["workflow.definition.version"].create(
+            {
+                "definition_id": cls.definition.id,
+                "bpmn_xml": "<xml/>",
+            }
+        )
+
+    def test_condition_rule_requires_value_by_type(self):
+        with self.assertRaises(ValidationError):
+            self.env["workflow.condition.rule"].create(
+                {
+                    "name": "Invalid Domain",
+                    "definition_version_id": self.version.id,
+                    "source_node_id": "Gateway_A",
+                    "target_node_id": "Task_A",
+                    "condition_type": "domain",
+                }
+            )
+
+        with self.assertRaises(ValidationError):
+            self.env["workflow.condition.rule"].create(
+                {
+                    "name": "Invalid Python",
+                    "definition_version_id": self.version.id,
+                    "source_node_id": "Gateway_A",
+                    "target_node_id": "Task_B",
+                    "condition_type": "python",
+                }
+            )
+
+        domain_rule = self.env["workflow.condition.rule"].create(
+            {
+                "name": "Valid Domain",
+                "definition_version_id": self.version.id,
+                "source_node_id": "Gateway_A",
+                "target_node_id": "Task_C",
+                "condition_type": "domain",
+                "domain_filter": json.dumps([["name", "=", "Alpha"]]),
+            }
+        )
+        self.assertTrue(domain_rule, "Domain rule should be created with valid domain_filter")
+
+        python_rule = self.env["workflow.condition.rule"].create(
+            {
+                "name": "Valid Python",
+                "definition_version_id": self.version.id,
+                "source_node_id": "Gateway_A",
+                "target_node_id": "Task_D",
+                "condition_type": "python",
+                "python_code": "record.name == 'Alpha'",
+            }
+        )
+        self.assertTrue(python_rule, "Python rule should be created with valid python_code")
+
+    def test_condition_rule_domain_filter_must_be_json_list(self):
+        with self.assertRaises(ValidationError):
+            self.env["workflow.condition.rule"].create(
+                {
+                    "name": "Invalid JSON",
+                    "definition_version_id": self.version.id,
+                    "source_node_id": "Gateway_B",
+                    "target_node_id": "Task_A",
+                    "condition_type": "domain",
+                    "domain_filter": "not-json",
+                }
+            )
+
+        with self.assertRaises(ValidationError):
+            self.env["workflow.condition.rule"].create(
+                {
+                    "name": "Invalid Domain Shape",
+                    "definition_version_id": self.version.id,
+                    "source_node_id": "Gateway_B",
+                    "target_node_id": "Task_B",
+                    "condition_type": "domain",
+                    "domain_filter": json.dumps({"name": "Alpha"}),
+                }
+            )
+
+    def test_condition_rule_evaluate_domain_and_python(self):
+        partner_true = self.env["res.partner"].create({"name": "Condition Alpha"})
+        partner_false = self.env["res.partner"].create({"name": "Condition Beta"})
+
+        domain_rule = self.env["workflow.condition.rule"].create(
+            {
+                "name": "Domain Eval",
+                "definition_version_id": self.version.id,
+                "source_node_id": "Gateway_C",
+                "target_node_id": "Task_A",
+                "condition_type": "domain",
+                "domain_filter": json.dumps([["name", "=", "Condition Alpha"]]),
+            }
+        )
+        self.assertTrue(domain_rule.evaluate(partner_true, {}), "Domain rule should match Condition Alpha")
+        self.assertFalse(domain_rule.evaluate(partner_false, {}), "Domain rule should reject Condition Beta")
+
+        python_rule = self.env["workflow.condition.rule"].create(
+            {
+                "name": "Python Eval",
+                "definition_version_id": self.version.id,
+                "source_node_id": "Gateway_C",
+                "target_node_id": "Task_B",
+                "condition_type": "python",
+                "python_code": "record.name.startswith('Condition A')",
+            }
+        )
+        self.assertTrue(python_rule.evaluate(partner_true, {}), "Python rule should match Condition Alpha")
+        self.assertFalse(python_rule.evaluate(partner_false, {}), "Python rule should reject Condition Beta")
+
+    def test_condition_rule_cascades_on_version_delete(self):
+        definition = self.env["workflow.definition"].create(
+            {
+                "name": "Cascade Definition",
+                "definition_key": "cascade_condition",
+            }
+        )
+        version = self.env["workflow.definition.version"].create(
+            {
+                "definition_id": definition.id,
+                "bpmn_xml": "<xml/>",
+            }
+        )
+        rule = self.env["workflow.condition.rule"].create(
+            {
+                "name": "Cascade Rule",
+                "definition_version_id": version.id,
+                "source_node_id": "Gateway_D",
+                "target_node_id": "Task_A",
+                "condition_type": "domain",
+                "domain_filter": json.dumps([["name", "=", "X"]]),
+            }
+        )
+        version.unlink()
+        self.assertFalse(
+            self.env["workflow.condition.rule"].search([("id", "=", rule.id)]),
+            "Condition rule should be deleted when definition version is deleted",
+        )
+
+    def test_follower_rule_required_fields_and_defaults(self):
+        with self.assertRaises(ValidationError):
+            self.env["workflow.follower.rule"].create(
+                {
+                    "name": "Group Missing",
+                    "definition_version_id": self.version.id,
+                    "follower_type": "group",
+                }
+            )
+
+        with self.assertRaises(ValidationError):
+            self.env["workflow.follower.rule"].create(
+                {
+                    "name": "Field Missing",
+                    "definition_version_id": self.version.id,
+                    "follower_type": "field",
+                }
+            )
+
+        requester_rule = self.env["workflow.follower.rule"].create(
+            {
+                "name": "Requester Rule",
+                "definition_version_id": self.version.id,
+                "follower_type": "requester",
+            }
+        )
+        self.assertEqual(
+            requester_rule.completion_policy,
+            "retained",
+            "Completion policy must default to retained",
+        )
+
+    def test_follower_rule_resolve_followers(self):
+        actor_user = self.env.ref("base.user_admin")
+        partner = self.env["res.partner"].create(
+            {
+                "name": "Owner Partner",
+                "user_id": actor_user.id,
+            }
+        )
+        group_user = self.env["res.groups"].create({"name": "Follower Rule Test Group"})
+        group_user.write({"user_ids": [(4, actor_user.id)]})
+
+        requester_rule = self.env["workflow.follower.rule"].create(
+            {
+                "name": "Requester",
+                "definition_version_id": self.version.id,
+                "follower_type": "requester",
+            }
+        )
+        requester_followers = requester_rule._resolve_followers(
+            requester=actor_user,
+            approvers=self.env["res.users"],
+            record=partner,
+        )
+        self.assertIn(actor_user, requester_followers, "Requester should be included for requester rule")
+
+        group_rule = self.env["workflow.follower.rule"].create(
+            {
+                "name": "Group",
+                "definition_version_id": self.version.id,
+                "follower_type": "group",
+                "group_id": group_user.id,
+            }
+        )
+        group_followers = group_rule._resolve_followers(
+            requester=actor_user,
+            approvers=self.env["res.users"],
+            record=partner,
+        )
+        self.assertIn(actor_user, group_followers, "Group rule should resolve to group users")
+
+        field_rule = self.env["workflow.follower.rule"].create(
+            {
+                "name": "Field",
+                "definition_version_id": self.version.id,
+                "follower_type": "field",
+                "field_path": "user_id",
+            }
+        )
+        field_followers = field_rule._resolve_followers(
+            requester=actor_user,
+            approvers=self.env["res.users"],
+            record=partner,
+        )
+        self.assertIn(actor_user, field_followers, "Field rule should resolve user_id from target record")
+
+    def test_follower_rule_cascades_on_version_delete(self):
+        definition = self.env["workflow.definition"].create(
+            {
+                "name": "Cascade Follower Definition",
+                "definition_key": "cascade_follower",
+            }
+        )
+        version = self.env["workflow.definition.version"].create(
+            {
+                "definition_id": definition.id,
+                "bpmn_xml": "<xml/>",
+            }
+        )
+        rule = self.env["workflow.follower.rule"].create(
+            {
+                "name": "Cascade Follower",
+                "definition_version_id": version.id,
+                "follower_type": "requester",
+            }
+        )
+        version.unlink()
+        self.assertFalse(
+            self.env["workflow.follower.rule"].search([("id", "=", rule.id)]),
+            "Follower rule should be deleted when definition version is deleted",
+        )


### PR DESCRIPTION
## Summary
- implement `workflow.condition.rule` contract behavior from OMB for field sizing/defaults/indexing and validation
- add condition evaluation helpers for `domain` and `python` rule types
- enforce one default transition per source node per definition version
- implement `workflow.follower.rule` completion policy and follower-type validation
- add follower resolution helpers for requester/approver/group/field modes
- add post-install transactional tests for condition/follower rule constraints, evaluation, and cascade deletes

## Verification
- `python -m py_compile dynamic_approval_workflow/dynamic_approval_core/models/workflow_condition_rule.py dynamic_approval_workflow/dynamic_approval_core/models/workflow_follower_rule.py dynamic_approval_workflow/dynamic_approval_core/tests/test_workflow_condition_follower_rule.py`
- `./odoo.sh -d test_p1_005_green8 -i dynamic_approval_core --test-enable --test-tags /dynamic_approval_core:TestWorkflowConditionFollowerRule --stop-after-init --without-demo`

## Notes
- `ruff` is not available in this environment (`command not found`).

TASK-P1-005
Closes #5
