### PR TITLE
test: add workflow definition P1 lifecycle and security tests

### DIFF
--- a/dynamic_approval_workflow/dynamic_approval_core/tests/test_workflow_definition.py
+++ b/dynamic_approval_workflow/dynamic_approval_core/tests/test_workflow_definition.py
@@ -1,7 +1,7 @@
 from psycopg2.errors import UniqueViolation
 
 from odoo import fields
-from odoo.exceptions import ValidationError
+from odoo.exceptions import AccessError, ValidationError
 from odoo.tests import tagged
 from odoo.tests.common import TransactionCase
 
@@ -18,12 +18,153 @@ class TestWorkflowDefinition(TransactionCase):
         super().setUpClass()
         cls.fixed_effective_from_utc = fields.Datetime.to_datetime("2026-01-01 00:00:00")
         cls.other_company = cls.env["res.company"].create({"name": "Other Company"})
+        cls.group_designer = cls.env.ref("dynamic_approval_core.group_workflow_designer")
+        cls.group_approver = cls.env.ref("dynamic_approval_core.group_workflow_approver")
+        cls.designer_user = cls.env["res.users"].with_context(no_reset_password=True).create(
+            {
+                "name": "Designer User",
+                "login": "designer_user@example.com",
+                "email": "designer_user@example.com",
+                "group_ids": [(6, 0, [cls.group_designer.id])],
+                "company_id": cls.env.company.id,
+                "company_ids": [(6, 0, [cls.env.company.id])],
+            }
+        )
+        cls.other_designer_user = cls.env["res.users"].with_context(no_reset_password=True).create(
+            {
+                "name": "Other Designer User",
+                "login": "designer_user_other@example.com",
+                "email": "designer_user_other@example.com",
+                "group_ids": [(6, 0, [cls.group_designer.id])],
+                "company_id": cls.other_company.id,
+                "company_ids": [(6, 0, [cls.other_company.id])],
+            }
+        )
+        cls.approver_user = cls.env["res.users"].with_context(no_reset_password=True).create(
+            {
+                "name": "Approver User",
+                "login": "approver_user@example.com",
+                "email": "approver_user@example.com",
+                "group_ids": [(6, 0, [cls.group_approver.id])],
+                "company_id": cls.env.company.id,
+                "company_ids": [(6, 0, [cls.env.company.id])],
+            }
+        )
         cls.definition = cls.env["workflow.definition"].create(
             {
                 "name": "Test Workflow",
                 "definition_key": "test_wf",
             }
         )
+
+    def test_definition_crud_lifecycle_create_publish_archive(self):
+        definition = self.env["workflow.definition"].create(
+            {
+                "name": "Lifecycle Workflow",
+                "definition_key": "lifecycle_wf",
+            }
+        )
+        self.assertTrue(definition.id, "Definition create step should persist record")
+
+        version = self.env["workflow.definition.version"].create(
+            {
+                "definition_id": definition.id,
+                "bpmn_xml": "<xml/>",
+                "effective_from_utc": self.fixed_effective_from_utc,
+            }
+        )
+        self.assertEqual(version.state, "draft", "New versions should start in draft state")
+
+        version.action_publish()
+        self.assertEqual(version.state, "published", "Publish should transition draft to published")
+
+        version.action_archive()
+        self.assertEqual(version.state, "archived", "Archive should transition published to archived")
+
+    def test_version_auto_increment_per_definition(self):
+        definition = self.env["workflow.definition"].create(
+            {
+                "name": "Increment Workflow",
+                "definition_key": "increment_wf",
+            }
+        )
+        version_1 = self.env["workflow.definition.version"].create(
+            {
+                "definition_id": definition.id,
+                "bpmn_xml": "<xml/>",
+                "effective_from_utc": self.fixed_effective_from_utc,
+            }
+        )
+        version_1.action_publish()
+
+        version_2 = self.env["workflow.definition.version"].create(
+            {
+                "definition_id": definition.id,
+                "bpmn_xml": "<xml/>",
+                "effective_from_utc": fields.Datetime.to_datetime("2026-02-01 00:00:00"),
+            }
+        )
+        version_2.action_publish()
+
+        self.assertEqual(version_1.version, 1, "First published version should be version 1")
+        self.assertEqual(version_2.version, 2, "Second published version should auto-increment to version 2")
+
+    def test_multi_company_isolation_record_rules(self):
+        main_definition = self.env["workflow.definition"].create(
+            {
+                "name": "Main Company Workflow",
+                "definition_key": "main_company_wf",
+                "company_id": self.env.company.id,
+            }
+        )
+        other_definition = self.env["workflow.definition"].create(
+            {
+                "name": "Other Company Workflow",
+                "definition_key": "other_company_wf",
+                "company_id": self.other_company.id,
+            }
+        )
+
+        visible_for_main_designer = self.env["workflow.definition"].with_user(self.designer_user).search(
+            [("id", "in", [main_definition.id, other_definition.id])]
+        )
+        self.assertIn(main_definition, visible_for_main_designer, "Main-company designer must see own company definitions")
+        self.assertNotIn(
+            other_definition,
+            visible_for_main_designer,
+            "Main-company designer must not see other-company definitions",
+        )
+
+        visible_for_other_designer = self.env["workflow.definition"].with_user(self.other_designer_user).search(
+            [("id", "in", [main_definition.id, other_definition.id])]
+        )
+        self.assertIn(
+            other_definition,
+            visible_for_other_designer,
+            "Other-company designer must see own company definitions",
+        )
+        self.assertNotIn(
+            main_definition,
+            visible_for_other_designer,
+            "Other-company designer must not see main-company definitions",
+        )
+
+    def test_security_group_permissions_designer_can_create_approver_cannot(self):
+        designer_definition = self.env["workflow.definition"].with_user(self.designer_user).create(
+            {
+                "name": "Designer Created Workflow",
+                "definition_key": "designer_created_wf",
+            }
+        )
+        self.assertTrue(designer_definition.id, "Designer user should be able to create workflow definitions")
+
+        with self.assertRaises(AccessError):
+            self.env["workflow.definition"].with_user(self.approver_user).create(
+                {
+                    "name": "Approver Created Workflow",
+                    "definition_key": "approver_created_wf",
+                }
+            )
 
     def test_create_definition(self):
         """DFR-01-001: create via UI without code changes."""


### PR DESCRIPTION
## Summary
- TASK-P1-010
- add P1 lifecycle test for workflow definition version flow (create -> publish -> archive)
- add auto-increment version test per definition
- add multi-company record-rule isolation test for workflow designers
- add security ACL test to ensure designers can create and approvers cannot
- create dedicated users/groups in test setup to validate role and company behavior

## Validation
- python3 -m py_compile dynamic_approval_workflow/dynamic_approval_core/tests/test_workflow_definition.py
- ./odoo.sh -d test_p1_010_green1 -i dynamic_approval_core --test-enable --test-tags /dynamic_approval_core:TestWorkflowDefinition --stop-after-init --without-demo

Closes #10