### PR TITLE
[ADD] dynamic_approval_core: complete token model with state machine and fork/join methods

### DIFF
--- a/dynamic_approval_workflow/dynamic_approval_core/models/workflow_token.py
+++ b/dynamic_approval_workflow/dynamic_approval_core/models/workflow_token.py
@@ -1,4 +1,9 @@
-from odoo import fields, models
+import uuid
+
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError, ValidationError
+
+from ..exceptions import WorkflowRuntimeError
 
 
 class WorkflowToken(models.Model):
@@ -8,27 +13,47 @@ class WorkflowToken(models.Model):
     (``active`` → ``consumed`` / ``cancelled``).
 
     SDS: §6.6 Token Management
-    SRS: FR-022, FR-024  |  DFR: DFR-04-013
+    SRS: FR-021, FR-022, FR-025  |  DFR: DFR-04-013
     """
 
     _name = "workflow.token"
     _description = "Workflow Token"
     _order = "instance_id, create_date"
 
+    _allowed_state_transitions = {
+        "active": {"consumed", "cancelled"},
+        "consumed": set(),
+        "cancelled": set(),
+    }
+    _managed_timestamp_fields = {"consumed_at_utc"}
+    _immutable_identity_fields = {"instance_id", "parent_token_id"}
+
     instance_id = fields.Many2one(
         "workflow.instance",
         required=True,
         ondelete="cascade",
         index=True,
+        readonly=True,
     )
     node_runtime_id = fields.Many2one(
         "workflow.node.runtime",
+        string="Current Node",
+        ondelete="set null",
         index=True,
     )
     parent_token_id = fields.Many2one(
         "workflow.token",
         string="Parent Token",
+        ondelete="set null",
         index=True,
+        readonly=True,
+    )
+    branch_id = fields.Char(
+        size=64,
+        string="Branch ID",
+        index=True,
+        readonly=True,
+        help="Parallel branch label assigned by _fork; siblings share a common prefix.",
     )
     state = fields.Selection(
         [
@@ -48,12 +73,227 @@ class WorkflowToken(models.Model):
         ],
     )
     created_at_utc = fields.Datetime(
+        string="Created At",
         default=fields.Datetime.now,
         readonly=True,
     )
-    consumed_at_utc = fields.Datetime(readonly=True)
+    consumed_at_utc = fields.Datetime(
+        string="Consumed At",
+        readonly=True,
+    )
     company_id = fields.Many2one(
+        "res.company",
+        string="Company",
         related="instance_id.company_id",
         store=True,
         index=True,
+        readonly=True,
     )
+
+    # SECURITY: workflow.token records are immutable audit artifacts.
+    # Deletion would corrupt the runtime execution history and break
+    # parallel branch tracking (parent/child lineage for fork/join).
+    # This override provides a fail-closed in-process guard.
+    # ACL enforcement: ir.model.access.csv grants perm_unlink=0 for all
+    # roles (token.admin row col 7 = 0; no unlink ACL for auditor).
+    # Both layers are required: ACL prevents direct ORM calls from UI/API;
+    # this override prevents bypasses from internal sudo() call sites.
+    def unlink(self):
+        raise UserError(
+            _("Workflow tokens cannot be deleted. Use state transitions instead.")
+        )
+
+    def write(self, vals):
+        """Enforce the token state machine, identity immutability, and managed timestamps."""
+        vals = dict(vals)
+
+        attempted_identity_updates = self._immutable_identity_fields.intersection(vals)
+        if attempted_identity_updates:
+            raise ValidationError(
+                _("Workflow token identity fields are immutable after creation.")
+            )
+
+        provided_timestamps = self._managed_timestamp_fields.intersection(vals)
+        if provided_timestamps:
+            raise ValidationError(
+                _("Token consumption timestamps are managed by state transitions.")
+            )
+
+        state = vals.get("state")
+        if not state:
+            return super().write(vals)
+
+        same_state_records = self.filtered(lambda r: r.state == state)
+        transition_records = self - same_state_records
+        result = True
+
+        if same_state_records:
+            non_state_vals = {k: v for k, v in vals.items() if k != "state"}
+            if non_state_vals:
+                result = super(WorkflowToken, same_state_records).write(non_state_vals) and result
+
+        if transition_records:
+            transition_records._validate_state_transition(state)
+            transition_vals = dict(vals)
+            if state == "consumed":
+                transition_vals["consumed_at_utc"] = fields.Datetime.now()
+            result = super(WorkflowToken, transition_records).write(transition_vals) and result
+
+        return result
+
+    def _validate_state_transition(self, next_state):
+        """Validate a requested state change against the token state machine."""
+        for record in self:
+            current_state = record.state
+            if current_state == next_state:
+                continue
+            allowed = self._allowed_state_transitions.get(current_state, set())
+            if next_state not in allowed:
+                raise ValidationError(
+                    _("Invalid token transition from '%(source)s' to '%(target)s'.")
+                    % {"source": current_state, "target": next_state}
+                )
+
+    @api.constrains("state", "consumed_at_utc")
+    def _check_state_timestamps(self):
+        """Keep timestamp invariants aligned with the token state machine."""
+        for record in self:
+            if record.state == "consumed" and not record.consumed_at_utc:
+                raise ValidationError(
+                    _("Consumed tokens must have a consumption timestamp.")
+                )
+            if record.state == "active" and record.consumed_at_utc:
+                raise ValidationError(
+                    _("Active tokens cannot have a consumption timestamp.")
+                )
+
+    @api.constrains("state", "cancel_reason")
+    def _check_cancel_reason(self):
+        """Ensure cancelled tokens have a reason and active/consumed do not."""
+        for record in self:
+            if record.state == "cancelled" and not record.cancel_reason:
+                raise ValidationError(
+                    _("Cancelled tokens must have a cancel reason.")
+                )
+            if record.state != "cancelled" and record.cancel_reason:
+                raise ValidationError(
+                    _("Only cancelled tokens can have a cancel reason.")
+                )
+
+    # ------------------------------------------------------------------
+    # Token operations — SDS §6.6
+    # ------------------------------------------------------------------
+
+    def _consume(self):
+        """Mark active tokens as consumed.
+
+        Sets state to ``consumed`` and records the consumption timestamp
+        (auto-managed by ``write()``). Operates on the full recordset.
+        """
+        non_active = self.filtered(lambda t: t.state != "active")
+        if non_active:
+            raise WorkflowRuntimeError(
+                _("Only active tokens can be consumed.")
+            )
+        self.write({"state": "consumed"})
+
+    def _advance(self, target_node_runtime):
+        """Consume this token and create one downstream child token.
+
+        Used for sequential flow: consume current → create one downstream.
+
+        :param target_node_runtime: ``workflow.node.runtime`` record for
+            the next node in the sequence.
+        :returns: newly created child token at the target node.
+        """
+        self.ensure_one()
+        self._consume()
+        return self.create({
+            "instance_id": self.instance_id.id,
+            "node_runtime_id": target_node_runtime.id,
+            "parent_token_id": self.id,
+        })
+
+    def _fork(self, target_node_runtimes):
+        """Consume this token and create N child tokens for parallel split.
+
+        Each child receives a unique ``branch_id`` derived from a shared
+        prefix so that sibling tokens can be identified via
+        ``parent_token_id`` for join resolution.
+
+        :param target_node_runtimes: recordset of ``workflow.node.runtime``
+            records — one child token is created per record.
+        :returns: recordset of newly created child tokens.
+        """
+        self.ensure_one()
+        if not target_node_runtimes:
+            raise WorkflowRuntimeError(
+                _("Parallel fork requires at least one target node runtime.")
+            )
+        self._consume()
+        branch_prefix = uuid.uuid4().hex[:16]
+        create_vals = [
+            {
+                "instance_id": self.instance_id.id,
+                "node_runtime_id": nr.id,
+                "parent_token_id": self.id,
+                "branch_id": "%s-%d" % (branch_prefix, idx),
+            }
+            for idx, nr in enumerate(target_node_runtimes)
+        ]
+        return self.create(create_vals)
+
+    def _join(self, join_type="all", quorum_threshold=None):
+        """Evaluate the join condition for a converging parallel gateway.
+
+        Checks whether sibling tokens (same ``parent_token_id``) satisfy
+        the join merge condition. This token must be active and is treated
+        as the arriving token (not yet consumed).
+
+        :param join_type: ``'all'`` (default), ``'any'``, or ``'quorum'``.
+        :param quorum_threshold: integer count required for ``'quorum'``
+            join type. Ignored for ``'all'`` and ``'any'``.
+        :returns: ``True`` if the join condition is satisfied and the
+            caller should proceed with downstream activation.
+            ``False`` if the token must wait for more siblings.
+        """
+        self.ensure_one()
+        if self.state != "active":
+            return False
+        if not self.parent_token_id:
+            return True
+
+        siblings = self.search([
+            ("parent_token_id", "=", self.parent_token_id.id),
+            ("id", "!=", self.id),
+        ])
+        total_branch_count = len(siblings) + 1
+
+        if join_type == "any":
+            self._cancel_remaining_siblings(siblings)
+            return True
+
+        if join_type == "quorum":
+            effective_threshold = (
+                quorum_threshold if quorum_threshold is not None else total_branch_count
+            )
+            arrived_count = len(
+                siblings.filtered(lambda t: t.state == "consumed")
+            ) + 1
+            if arrived_count >= effective_threshold:
+                self._cancel_remaining_siblings(siblings)
+                return True
+            return False
+
+        # Default: "all" — every sibling must be consumed
+        active_siblings = siblings.filtered(lambda t: t.state == "active")
+        return not active_siblings
+
+    def _cancel_remaining_siblings(self, siblings):
+        """Cancel active sibling tokens that are superseded by the join."""
+        active_siblings = siblings.filtered(lambda t: t.state == "active")
+        if active_siblings:
+            active_siblings.write({
+                "state": "cancelled",
+                "cancel_reason": "branch_superseded",
+            })

--- a/dynamic_approval_workflow/dynamic_approval_core/models/workflow_token.py
+++ b/dynamic_approval_workflow/dynamic_approval_core/models/workflow_token.py
@@ -26,7 +26,7 @@ class WorkflowToken(models.Model):
         "cancelled": set(),
     }
     _managed_timestamp_fields = {"consumed_at_utc"}
-    _immutable_identity_fields = {"instance_id", "parent_token_id"}
+    _immutable_identity_fields = {"instance_id", "parent_token_id", "branch_id"}
 
     instance_id = fields.Many2one(
         "workflow.instance",
@@ -120,7 +120,7 @@ class WorkflowToken(models.Model):
             )
 
         state = vals.get("state")
-        if not state:
+        if state is None:
             return super().write(vals)
 
         same_state_records = self.filtered(lambda r: r.state == state)
@@ -166,6 +166,10 @@ class WorkflowToken(models.Model):
                 raise ValidationError(
                     _("Active tokens cannot have a consumption timestamp.")
                 )
+            if record.state == "cancelled" and record.consumed_at_utc:
+                raise ValidationError(
+                    _("Cancelled tokens cannot have a consumption timestamp.")
+                )
 
     @api.constrains("state", "cancel_reason")
     def _check_cancel_reason(self):
@@ -207,6 +211,10 @@ class WorkflowToken(models.Model):
         :returns: newly created child token at the target node.
         """
         self.ensure_one()
+        if target_node_runtime.instance_id != self.instance_id:
+            raise WorkflowRuntimeError(
+                _("Target node runtime belongs to a different workflow instance.")
+            )
         self._consume()
         return self.create({
             "instance_id": self.instance_id.id,
@@ -229,6 +237,13 @@ class WorkflowToken(models.Model):
         if not target_node_runtimes:
             raise WorkflowRuntimeError(
                 _("Parallel fork requires at least one target node runtime.")
+            )
+        mismatched = target_node_runtimes.filtered(
+            lambda nr: nr.instance_id != self.instance_id
+        )
+        if mismatched:
+            raise WorkflowRuntimeError(
+                _("Target node runtime belongs to a different workflow instance.")
             )
         self._consume()
         branch_prefix = uuid.uuid4().hex[:16]
@@ -256,6 +271,11 @@ class WorkflowToken(models.Model):
         :returns: ``True`` if the join condition is satisfied and the
             caller should proceed with downstream activation.
             ``False`` if the token must wait for more siblings.
+
+        .. warning::
+            Callers must hold the per-instance ``pg_advisory_xact_lock``
+            (SDS §6.4) before invoking this method to prevent concurrent
+            double-trigger in multi-worker deployments.
         """
         self.ensure_one()
         if self.state != "active":
@@ -267,27 +287,34 @@ class WorkflowToken(models.Model):
             ("parent_token_id", "=", self.parent_token_id.id),
             ("id", "!=", self.id),
         ])
-        total_branch_count = len(siblings) + 1
 
         if join_type == "any":
             self._cancel_remaining_siblings(siblings)
             return True
 
         if join_type == "quorum":
+            # Exclude already-cancelled siblings from denominator to avoid
+            # livelock when branches were cancelled upstream.
+            live_siblings = siblings.filtered(lambda t: t.state != "cancelled")
+            live_branch_count = len(live_siblings) + 1  # +1 for self (arriving)
             effective_threshold = (
-                quorum_threshold if quorum_threshold is not None else total_branch_count
+                quorum_threshold if quorum_threshold is not None else live_branch_count
             )
             arrived_count = len(
                 siblings.filtered(lambda t: t.state == "consumed")
-            ) + 1
+            ) + 1  # +1 for self (arriving, still active)
             if arrived_count >= effective_threshold:
                 self._cancel_remaining_siblings(siblings)
                 return True
             return False
 
-        # Default: "all" — every sibling must be consumed
-        active_siblings = siblings.filtered(lambda t: t.state == "active")
-        return not active_siblings
+        # Default: "all" — every live sibling must be consumed.
+        # Cancelled siblings are treated as "done" to prevent livelock
+        # when branches were cancelled upstream or by a prior join.
+        pending_siblings = siblings.filtered(
+            lambda t: t.state not in ("consumed", "cancelled")
+        )
+        return not pending_siblings
 
     def _cancel_remaining_siblings(self, siblings):
         """Cancel active sibling tokens that are superseded by the join."""

--- a/dynamic_approval_workflow/dynamic_approval_core/tests/__init__.py
+++ b/dynamic_approval_workflow/dynamic_approval_core/tests/__init__.py
@@ -16,3 +16,4 @@ from . import test_workflow_incident as test_workflow_incident
 from . import test_workflow_approval_mixin as test_workflow_approval_mixin
 from . import test_workflow_cron as test_workflow_cron
 from . import test_workflow_node_runtime as test_workflow_node_runtime
+from . import test_workflow_token as test_workflow_token

--- a/dynamic_approval_workflow/dynamic_approval_core/tests/test_workflow_token.py
+++ b/dynamic_approval_workflow/dynamic_approval_core/tests/test_workflow_token.py
@@ -1,0 +1,395 @@
+from odoo.exceptions import UserError, ValidationError
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase
+
+from ..exceptions import WorkflowRuntimeError
+
+
+@tagged("post_install", "-at_install")
+class TestWorkflowToken(TransactionCase):
+    """Tests for TASK-P3-003 workflow token state machine and fork/join operations."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.definition = cls.env["workflow.definition"].create(
+            {
+                "name": "Token Test Workflow",
+                "definition_key": "token_test_workflow",
+            }
+        )
+        cls.definition_version = cls.env["workflow.definition.version"].create(
+            {
+                "definition_id": cls.definition.id,
+                "bpmn_xml": "<definitions/>",
+            }
+        )
+        cls.partner = cls.env["res.partner"].create({"name": "Token Test Resource"})
+        cls.instance = cls.env["workflow.instance"].create(
+            {
+                "definition_id": cls.definition.id,
+                "definition_version_id": cls.definition_version.id,
+                "res_model": "res.partner",
+                "res_id": cls.partner.id,
+            }
+        )
+        # Second instance for cross-instance guard tests
+        cls.other_instance = cls.env["workflow.instance"].create(
+            {
+                "definition_id": cls.definition.id,
+                "definition_version_id": cls.definition_version.id,
+                "res_model": "res.partner",
+                "res_id": cls.partner.id,
+            }
+        )
+
+    def _create_node_runtime(self, instance=None, **overrides):
+        """Create a node runtime with overridable defaults."""
+        values = {
+            "instance_id": (instance or self.instance).id,
+            "node_id": "Activity_1",
+            "node_type": "user_task",
+        }
+        values.update(overrides)
+        return self.env["workflow.node.runtime"].create(values)
+
+    def _create_token(self, **overrides):
+        """Create a token with overridable defaults."""
+        values = {
+            "instance_id": self.instance.id,
+        }
+        values.update(overrides)
+        return self.env["workflow.token"].create(values)
+
+    # ------------------------------------------------------------------
+    # Field defaults and creation
+    # ------------------------------------------------------------------
+
+    def test_create_sets_default_state_active(self):
+        """DFR-04-013: tokens default to active state."""
+        token = self._create_token()
+        self.assertEqual(token.state, "active")
+        self.assertTrue(token.created_at_utc)
+        self.assertFalse(token.consumed_at_utc)
+        self.assertFalse(token.cancel_reason)
+
+    def test_create_sets_company_from_instance(self):
+        """DFR-04-013: company_id is related from instance."""
+        token = self._create_token()
+        self.assertEqual(token.company_id, self.instance.company_id)
+
+    # ------------------------------------------------------------------
+    # Unlink immutability
+    # ------------------------------------------------------------------
+
+    def test_unlink_raises_user_error(self):
+        """NFR-002: tokens cannot be deleted — state transitions only."""
+        token = self._create_token()
+        with self.assertRaises(UserError, msg="Token deletion must be blocked."):
+            token.unlink()
+
+    # ------------------------------------------------------------------
+    # State machine — valid transitions
+    # ------------------------------------------------------------------
+
+    def test_transition_active_to_consumed(self):
+        """FR-021: active token can be consumed."""
+        token = self._create_token()
+        token.write({"state": "consumed"})
+        self.assertEqual(token.state, "consumed")
+        self.assertTrue(token.consumed_at_utc, "consumed_at_utc must be auto-set.")
+
+    def test_transition_active_to_cancelled(self):
+        """FR-025: active token can be cancelled with a reason."""
+        token = self._create_token()
+        token.write({"state": "cancelled", "cancel_reason": "rework"})
+        self.assertEqual(token.state, "cancelled")
+        self.assertFalse(token.consumed_at_utc)
+
+    # ------------------------------------------------------------------
+    # State machine — invalid transitions
+    # ------------------------------------------------------------------
+
+    def test_transition_consumed_to_active_blocked(self):
+        """DFR-04-013: consumed tokens cannot revert to active."""
+        token = self._create_token()
+        token.write({"state": "consumed"})
+        with self.assertRaises(ValidationError):
+            token.write({"state": "active"})
+
+    def test_transition_cancelled_to_active_blocked(self):
+        """DFR-04-013: cancelled tokens cannot revert to active."""
+        token = self._create_token()
+        token.write({"state": "cancelled", "cancel_reason": "rework"})
+        with self.assertRaises(ValidationError):
+            token.write({"state": "active"})
+
+    def test_transition_consumed_to_cancelled_blocked(self):
+        """DFR-04-013: consumed tokens cannot be cancelled."""
+        token = self._create_token()
+        token.write({"state": "consumed"})
+        with self.assertRaises(ValidationError):
+            token.write({"state": "cancelled", "cancel_reason": "rework"})
+
+    # ------------------------------------------------------------------
+    # Identity immutability
+    # ------------------------------------------------------------------
+
+    def test_write_rejects_instance_id_mutation(self):
+        """DFR-04-013: instance_id is immutable after creation."""
+        token = self._create_token()
+        with self.assertRaises(ValidationError):
+            token.write({"instance_id": self.other_instance.id})
+
+    def test_write_rejects_parent_token_id_mutation(self):
+        """DFR-04-013: parent_token_id is immutable after creation."""
+        token = self._create_token()
+        other_token = self._create_token()
+        with self.assertRaises(ValidationError):
+            token.write({"parent_token_id": other_token.id})
+
+    def test_write_rejects_branch_id_mutation(self):
+        """DFR-04-013: branch_id is immutable after creation."""
+        token = self._create_token()
+        with self.assertRaises(ValidationError):
+            token.write({"branch_id": "mutated-branch"})
+
+    # ------------------------------------------------------------------
+    # Managed timestamps
+    # ------------------------------------------------------------------
+
+    def test_write_rejects_manual_consumed_at_utc(self):
+        """DFR-04-013: consumed_at_utc is managed by state transitions."""
+        token = self._create_token()
+        with self.assertRaises(ValidationError):
+            token.write({"consumed_at_utc": "2026-03-10 00:00:00"})
+
+    # ------------------------------------------------------------------
+    # Constraint validators
+    # ------------------------------------------------------------------
+
+    def test_cancelled_token_requires_cancel_reason(self):
+        """DFR-04-013: cancelled tokens must have a cancel_reason."""
+        token = self._create_token()
+        with self.assertRaises(ValidationError):
+            token.write({"state": "cancelled"})
+
+    def test_active_token_rejects_cancel_reason(self):
+        """DFR-04-013: active tokens must not have a cancel_reason."""
+        with self.assertRaises(ValidationError):
+            self._create_token(cancel_reason="rework")
+
+    # ------------------------------------------------------------------
+    # _consume
+    # ------------------------------------------------------------------
+
+    def test_consume_marks_active_tokens_consumed(self):
+        """SDS §6.6: _consume sets state to consumed with timestamp."""
+        token = self._create_token()
+        token._consume()
+        self.assertEqual(token.state, "consumed")
+        self.assertTrue(token.consumed_at_utc)
+
+    def test_consume_rejects_non_active_tokens(self):
+        """SDS §6.6: _consume raises on already-consumed tokens."""
+        token = self._create_token()
+        token._consume()
+        with self.assertRaises(WorkflowRuntimeError):
+            token._consume()
+
+    # ------------------------------------------------------------------
+    # _advance
+    # ------------------------------------------------------------------
+
+    def test_advance_creates_child_at_target_node(self):
+        """FR-021: _advance consumes parent and creates child at target."""
+        node_a = self._create_node_runtime(node_id="Node_A")
+        node_b = self._create_node_runtime(node_id="Node_B")
+        token = self._create_token(node_runtime_id=node_a.id)
+
+        child = token._advance(node_b)
+
+        self.assertEqual(token.state, "consumed")
+        self.assertEqual(child.state, "active")
+        self.assertEqual(child.node_runtime_id, node_b)
+        self.assertEqual(child.parent_token_id, token)
+        self.assertEqual(child.instance_id, self.instance)
+
+    def test_advance_rejects_cross_instance_target(self):
+        """DFR-04-013: _advance blocks cross-instance node runtimes."""
+        node_a = self._create_node_runtime(node_id="Node_A")
+        other_node = self._create_node_runtime(
+            instance=self.other_instance, node_id="Node_Other"
+        )
+        token = self._create_token(node_runtime_id=node_a.id)
+
+        with self.assertRaises(WorkflowRuntimeError):
+            token._advance(other_node)
+
+    # ------------------------------------------------------------------
+    # _fork
+    # ------------------------------------------------------------------
+
+    def test_fork_creates_n_children_with_unique_branch_ids(self):
+        """FR-022: _fork creates N children with unique branch IDs."""
+        node_a = self._create_node_runtime(node_id="Node_A")
+        node_b = self._create_node_runtime(node_id="Node_B")
+        node_c = self._create_node_runtime(node_id="Node_C")
+        token = self._create_token()
+
+        children = token._fork(node_a | node_b | node_c)
+
+        self.assertEqual(token.state, "consumed")
+        self.assertEqual(len(children), 3)
+        branch_ids = children.mapped("branch_id")
+        self.assertEqual(len(set(branch_ids)), 3, "Each child must have a unique branch_id.")
+        for child in children:
+            self.assertEqual(child.parent_token_id, token)
+            self.assertEqual(child.state, "active")
+
+    def test_fork_rejects_empty_targets(self):
+        """FR-022: _fork requires at least one target node runtime."""
+        token = self._create_token()
+        empty = self.env["workflow.node.runtime"]
+        with self.assertRaises(WorkflowRuntimeError):
+            token._fork(empty)
+
+    def test_fork_rejects_cross_instance_targets(self):
+        """DFR-04-013: _fork blocks cross-instance node runtimes."""
+        other_node = self._create_node_runtime(
+            instance=self.other_instance, node_id="Node_Other"
+        )
+        token = self._create_token()
+        with self.assertRaises(WorkflowRuntimeError):
+            token._fork(other_node)
+
+    # ------------------------------------------------------------------
+    # _join("all")
+    # ------------------------------------------------------------------
+
+    def test_join_all_waits_for_active_siblings(self):
+        """FR-022: _join('all') returns False while siblings are active."""
+        node_a = self._create_node_runtime(node_id="Node_A")
+        node_b = self._create_node_runtime(node_id="Node_B")
+        parent = self._create_token()
+        children = parent._fork(node_a | node_b)
+        child_a = children[0]
+
+        self.assertFalse(child_a._join("all"), "Join should wait while sibling is active.")
+
+    def test_join_all_completes_when_all_consumed(self):
+        """FR-022: _join('all') returns True when all siblings consumed."""
+        node_a = self._create_node_runtime(node_id="Node_A")
+        node_b = self._create_node_runtime(node_id="Node_B")
+        parent = self._create_token()
+        children = parent._fork(node_a | node_b)
+        child_a, child_b = children[0], children[1]
+
+        child_a._consume()
+        self.assertTrue(child_b._join("all"), "Join should complete when all siblings consumed.")
+
+    def test_join_all_treats_cancelled_siblings_as_done(self):
+        """FR-022: _join('all') does not livelock on cancelled siblings."""
+        node_a = self._create_node_runtime(node_id="Node_A")
+        node_b = self._create_node_runtime(node_id="Node_B")
+        node_c = self._create_node_runtime(node_id="Node_C")
+        parent = self._create_token()
+        children = parent._fork(node_a | node_b | node_c)
+        child_a, child_b, child_c = children[0], children[1], children[2]
+
+        child_a._consume()
+        child_b.write({"state": "cancelled", "cancel_reason": "branch_superseded"})
+        self.assertTrue(
+            child_c._join("all"),
+            "Join should complete when remaining siblings are consumed or cancelled.",
+        )
+
+    # ------------------------------------------------------------------
+    # _join("any")
+    # ------------------------------------------------------------------
+
+    def test_join_any_returns_true_immediately(self):
+        """FR-022: _join('any') completes on first arrival."""
+        node_a = self._create_node_runtime(node_id="Node_A")
+        node_b = self._create_node_runtime(node_id="Node_B")
+        parent = self._create_token()
+        children = parent._fork(node_a | node_b)
+        child_a, child_b = children[0], children[1]
+
+        self.assertTrue(child_a._join("any"))
+        child_b.invalidate_recordset()
+        self.assertEqual(
+            child_b.state, "cancelled",
+            "Remaining siblings must be cancelled with branch_superseded.",
+        )
+        self.assertEqual(child_b.cancel_reason, "branch_superseded")
+
+    # ------------------------------------------------------------------
+    # _join("quorum")
+    # ------------------------------------------------------------------
+
+    def test_join_quorum_waits_until_threshold_met(self):
+        """FR-022: _join('quorum') waits until threshold met."""
+        node_a = self._create_node_runtime(node_id="Node_A")
+        node_b = self._create_node_runtime(node_id="Node_B")
+        node_c = self._create_node_runtime(node_id="Node_C")
+        parent = self._create_token()
+        children = parent._fork(node_a | node_b | node_c)
+        child_a, child_b = children[0], children[1]
+
+        # Only 1 arrived (self), threshold is 2
+        self.assertFalse(child_a._join("quorum", quorum_threshold=2))
+
+        # Now child_a consumed, child_b arriving → 2 arrived
+        child_a._consume()
+        self.assertTrue(child_b._join("quorum", quorum_threshold=2))
+
+    def test_join_quorum_excludes_cancelled_from_default_threshold(self):
+        """FR-022: _join('quorum') default threshold excludes cancelled siblings."""
+        node_a = self._create_node_runtime(node_id="Node_A")
+        node_b = self._create_node_runtime(node_id="Node_B")
+        node_c = self._create_node_runtime(node_id="Node_C")
+        parent = self._create_token()
+        children = parent._fork(node_a | node_b | node_c)
+        child_a, child_b, child_c = children[0], children[1], children[2]
+
+        # Cancel child_c upstream
+        child_c.write({"state": "cancelled", "cancel_reason": "branch_superseded"})
+
+        # Now default threshold should be 2 (live branches only), not 3
+        child_a._consume()
+        self.assertTrue(
+            child_b._join("quorum"),
+            "Default quorum threshold should exclude cancelled siblings.",
+        )
+
+    # ------------------------------------------------------------------
+    # _join edge cases
+    # ------------------------------------------------------------------
+
+    def test_join_root_token_always_satisfies(self):
+        """SDS §6.6: root tokens (no parent) always satisfy join."""
+        token = self._create_token()
+        self.assertTrue(token._join("all"))
+
+    def test_join_non_active_token_returns_false(self):
+        """SDS §6.6: consumed tokens cannot satisfy join."""
+        token = self._create_token()
+        token._consume()
+        self.assertFalse(token._join("all"))
+
+    # ------------------------------------------------------------------
+    # Same-state write (no-op for state)
+    # ------------------------------------------------------------------
+
+    def test_same_state_write_does_not_restamp(self):
+        """DFR-04-013: same-state writes must not trigger new timestamps."""
+        token = self._create_token()
+        token.write({"state": "consumed"})
+        consumed_at = token.consumed_at_utc
+        token.write({"state": "consumed"})
+        self.assertEqual(
+            token.consumed_at_utc,
+            consumed_at,
+            "Same-state write must not re-stamp consumed_at_utc.",
+        )


### PR DESCRIPTION
## Summary

- Complete `workflow.token` model implementation per OMB-01 §10 and SDS §6.6
- Add missing fields: `branch_id` (Char(64)), `readonly`/`ondelete` attributes per field spec
- Add state machine enforcement in `write()` with `_allowed_state_transitions` (active → consumed/cancelled)
- Add identity immutability guard for `instance_id` and `parent_token_id` (consistent with `workflow.node.runtime` pattern)
- Add `unlink()` override with full SECURITY comment per LESSON-006
- Implement `_consume()`, `_advance()`, `_fork()`, `_join()` token operations
- `_join()` supports `all`, `any`, and `quorum` merge semantics with sibling cancellation
- Add `@api.constrains` validators for timestamp and cancel_reason invariants

Task ID: TASK-P3-003
Closes #23

## Verification

- [x] `py_compile` — syntax OK
- [x] `ruff check` — all checks passed
- [x] `check_odoo19_compat.py` — 21 XML files scanned, passed

## Test plan

- [ ] Module install: `odoo-bin -d test_db -i dynamic_approval_core --stop-after-init`
- [ ] Token creation with default state `active`
- [ ] State transitions: active→consumed (timestamp set), active→cancelled (reason required)
- [ ] Blocked transitions: consumed→active, cancelled→active raise ValidationError
- [ ] `unlink()` raises UserError on any delete attempt
- [ ] `_advance()` consumes parent, creates child at target node
- [ ] `_fork()` consumes parent, creates N children with unique branch_ids
- [ ] `_join("all")` returns True only when all siblings consumed
- [ ] `_join("any")` returns True immediately, cancels remaining siblings
- [ ] `_join("quorum", threshold)` returns True when threshold met
- [ ] Identity fields (instance_id, parent_token_id) blocked from mutation